### PR TITLE
Fix XWiki page content fetch URL (remove duplicate /xwiki prefix)

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,11 +127,11 @@ async def search_xwiki(query: str, limit: int = 10, offset: int = 0) -> List[Sea
             print(f"🔍 DEBUG: Fetching full content for pageFullName='{item.get('pageFullName', '')}'") # DEBUG
             page_full_name = item.get('pageFullName', '')
             encoded_page_name = quote(page_full_name, safe='')  # ← ДОБАВИТЬ
-            print(f"🔗 DEBUG: Requested URL = {XWIKI_BASE_URL}/xwiki/rest/wikis/xwiki/pages/{encoded_page_name}/content") # DEBUG
+            print(f"🔗 DEBUG: Requested URL = {XWIKI_BASE_URL}/rest/wikis/xwiki/pages/{encoded_page_name}/content") # DEBUG
             try:
                 # попытаемся получить ПОЛНЫЙ контент страницы отдельным запросом
                 page_resp = await client.get(
-                    f"{XWIKI_BASE_URL}/xwiki/rest/wikis/xwiki/pages/{encoded_page_name}/content",
+                    f"{XWIKI_BASE_URL}/rest/wikis/xwiki/pages/{encoded_page_name}/content",
                     auth=(XWIKI_USERNAME, XWIKI_PASSWORD),
                     follow_redirects=True
                 )


### PR DESCRIPTION
### Motivation
- The XWiki full-page fetch used a duplicated `/xwiki` segment which led to 404 responses and empty retrieval snippets.

### Description
- Updated `search_xwiki` in `main.py` to use `.../rest/wikis/xwiki/pages/{encoded_page_name}/content` and adjusted the debug log to match the actual requested URL.

### Testing
- Ran `python -m py_compile main.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698478441a9c8326b03261555a290f46)